### PR TITLE
Add a command layer for Resource Monitor commands

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -308,38 +308,22 @@ def getWinVer() -> str:
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	# Translators: The gestures category for this add-on in input gestures dialog (2013.3 or later).
 	scriptCategory = _("Resource Monitor")
-	__gestures = {"kb:NVDA+shift+e": "layerEntry"}
 	__layerGestures = {
 		"kb:space": "announceResourceSummary",
 		"kb:c": "announceProcessorInfo",
 		"kb:m": "announceRamInfo",
 		"kb:d": "announceDriveInfo",
 		"kb:w": "wlanStatusReport",
-		"kb:v": "announceWinVer",
+		"kb:o": "announceWinVer",
 		"kb:u": "announceUptime",
 		"kb:g": "announceGpuInfo",
-		"kb:r": "announceGpuMemoryInfo",
+		"kb:shift+g": "announceGpuMemoryInfo",
 		"kb:escape": "layerExit",
 	}
-	_layerStayScripts = frozenset(
-		{
-			"script_layerExit",
-			"script_announceResourceSummary",
-			"script_announceProcessorInfo",
-			"script_announceRamInfo",
-			"script_announceDriveInfo",
-			"script_wlanStatusReport",
-			"script_announceWinVer",
-			"script_announceUptime",
-			"script_announceGpuInfo",
-			"script_announceGpuMemoryInfo",
-		}
-	)
 
 	def __init__(self):
 		super().__init__()
 		self._isLayerActive = False
-		self._layerWrappers: dict[Any, Any] = {}
 		self._gpuProviders: list[BaseGpuProvider] = getGpuProviders()
 		NVDASettingsDialog.categoryClasses.append(ResourceMonitorSettingsPanel)
 		if not wlanapiAvailable:
@@ -396,66 +380,41 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"""Resolve gestures through the resource monitor command layer."""
 		if not self._isLayerActive:
 			return super().getScript(gesture)
-		script = super().getScript(gesture)
-		if not script:
-			return self._handleLayerError
-		if getattr(script, "__name__", "") in self._layerStayScripts:
-			return script
-
-		scriptFunction = getattr(script, "__func__", script)
-		if scriptFunction not in self._layerWrappers:
-
-			@functools.wraps(script)
-			def wrappedScript(layerGesture: inputCore.InputGesture):
-				try:
-					script(layerGesture)
-				finally:
-					self._finishLayer()
-
-			self._layerWrappers[scriptFunction] = wrappedScript
-
-		return self._layerWrappers[scriptFunction]
+		return super().getScript(gesture) or self._handleUnboundLayerGesture
 
 	def _finishLayer(self) -> None:
 		"""Leave the resource monitor command layer."""
 		self._isLayerActive = False
-		self.clearGestureBindings()
-		self.bindGestures(self.__gestures)
+		for gestureIdentifier in self.__layerGestures:
+			self.removeGestureBinding(gestureIdentifier)
 
-	def _handleLayerError(self, gesture: inputCore.InputGesture) -> None:
-		"""Report an unbound command-layer gesture and pass it through."""
-		tones.beep(440, 100)
+	def _handleUnboundLayerGesture(self, gesture: inputCore.InputGesture) -> None:
+		"""Leave the command layer and pass through an unbound gesture."""
 		self._finishLayer()
 		try:
 			gesture.send()
 		except NotImplementedError:
 			pass
 
-	def _getResourceSummary(self) -> str:
-		"""Build the overall resource usage summary."""
-		return _("{ramPercent}% RAM used, CPU at {cpuPercent}%.").format(
-			ramPercent=tryTrunk(psutil.virtual_memory()[2]), cpuPercent=tryTrunk(psutil.cpu_percent())
-		)
-
 	@scriptHandler.script(
 		# Translators: Input help mode message for entering the Resource Monitor command layer.
 		description=_("Enter the Resource Monitor command layer."),
-		speakOnDemand=True,
+		gesture="kb:NVDA+shift+e",
 	)
 	def script_layerEntry(self, gesture: inputCore.InputGesture):
 		"""Enter the Resource Monitor command layer."""
 		if self._isLayerActive:
-			self._handleLayerError(gesture)
+			self._handleUnboundLayerGesture(gesture)
 			return
 		self.bindGestures(self.__layerGestures)
 		self._isLayerActive = True
 		tones.beep(100, 10)
-		# Translators: Prompt shown after entering the Resource Monitor command layer.
-		ui.message(f"{self._getResourceSummary()} {_('Press a letter for more information.')}")
 
 	@scriptHandler.script(allowInSleepMode=True)
 	def script_layerExit(self, gesture: inputCore.InputGesture):
+		"""Exit the Resource Monitor command layer."""
 		self._finishLayer()
+		tones.beep(120, 100)
 
 	@scriptHandler.script(
 		# Translators: Input help mode message about overall system resource info command in Resource Monitor
@@ -466,9 +425,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		speakOnDemand=True,
 	)
 	def script_announceResourceSummary(self, gesture: inputCore.InputGesture):
-		# Faster to build info on the fly rather than keep appending to a string.
 		# Translators: presents the overall summary of resource usage, such as CPU load and RAM usage.
-		info = self._getResourceSummary()
+		info = _("{ramPercent}% RAM used, CPU at {cpuPercent}%.").format(
+			ramPercent=tryTrunk(psutil.virtual_memory()[2]), cpuPercent=tryTrunk(psutil.cpu_percent())
+		)
 		if scriptHandler.getLastScriptRepeatCount() == 0:
 			ui.message(info)
 		else:
@@ -480,6 +440,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Presents the average processor load and the load of each core. "
 			"If pressed twice, copies the information to the clipboard."
 		),
+		gesture="KB:NVDA+shift+1",
 		speakOnDemand=True,
 	)
 	def script_announceProcessorInfo(self, gesture: inputCore.InputGesture):
@@ -512,6 +473,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Presents the used and total space for both physical and virtual ram. "
 			"If pressed twice, copies the information to the clipboard."
 		),
+		gestures=["KB:NVDA+shift+2", "KB:NVDA+shift+5"],
 		speakOnDemand=True,
 	)
 	def script_announceRamInfo(self, gesture: inputCore.InputGesture):
@@ -542,6 +504,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Presents the used and total space of the fixed (built-in), removable, and mapped network drives on this computer. "
 			"If pressed twice, copies the information to the clipboard."
 		),
+		gesture="KB:NVDA+shift+3",
 		speakOnDemand=True,
 	)
 	def script_announceDriveInfo(self, gesture: inputCore.InputGesture):
@@ -631,6 +594,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Announces the system's wireless network name (SSID), connection strength, and security  protocol. "
 			"If pressed twice, copies the information to the clipboard."
 		),
+		gesture="kb:NVDA+shift+4",
 		speakOnDemand=True,
 	)
 	def script_wlanStatusReport(self, gesture: inputCore.InputGesture):
@@ -646,6 +610,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Announces the version of Windows you are using. "
 			"If pressed twice, copies the information to the clipboard."
 		),
+		gesture="KB:NVDA+shift+6",
 		speakOnDemand=True,
 	)
 	def script_announceWinVer(self, gesture: inputCore.InputGesture):
@@ -689,6 +654,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Announces the system's uptime. "
 			"If pressed twice, copies the information to the clipboard."
 		),
+		gesture="kb:NVDA+shift+7",
 		speakOnDemand=True,
 	)
 	def script_announceUptime(self, gesture: inputCore.InputGesture):

--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -17,6 +17,7 @@ import globalPluginHandler
 import queueHandler
 import scriptHandler
 import inputCore
+import tones
 import ui
 import winVersion
 import wx
@@ -307,9 +308,38 @@ def getWinVer() -> str:
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	# Translators: The gestures category for this add-on in input gestures dialog (2013.3 or later).
 	scriptCategory = _("Resource Monitor")
+	__gestures = {"kb:NVDA+shift+e": "layerEntry"}
+	__layerGestures = {
+		"kb:space": "announceResourceSummary",
+		"kb:c": "announceProcessorInfo",
+		"kb:m": "announceRamInfo",
+		"kb:d": "announceDriveInfo",
+		"kb:w": "wlanStatusReport",
+		"kb:v": "announceWinVer",
+		"kb:u": "announceUptime",
+		"kb:g": "announceGpuInfo",
+		"kb:r": "announceGpuMemoryInfo",
+		"kb:escape": "layerExit",
+	}
+	_layerStayScripts = frozenset(
+		{
+			"script_layerExit",
+			"script_announceResourceSummary",
+			"script_announceProcessorInfo",
+			"script_announceRamInfo",
+			"script_announceDriveInfo",
+			"script_wlanStatusReport",
+			"script_announceWinVer",
+			"script_announceUptime",
+			"script_announceGpuInfo",
+			"script_announceGpuMemoryInfo",
+		}
+	)
 
 	def __init__(self):
 		super().__init__()
+		self._isLayerActive = False
+		self._layerWrappers: dict[Any, Any] = {}
 		self._gpuProviders: list[BaseGpuProvider] = getGpuProviders()
 		NVDASettingsDialog.categoryClasses.append(ResourceMonitorSettingsPanel)
 		if not wlanapiAvailable:
@@ -362,21 +392,87 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		except OSError:
 			pass
 
+	def getScript(self, gesture: inputCore.InputGesture):
+		"""Resolve gestures through the resource monitor command layer."""
+		if not self._isLayerActive:
+			return super().getScript(gesture)
+		script = super().getScript(gesture)
+		if not script:
+			return self._handleLayerError
+		if getattr(script, "__name__", "") in self._layerStayScripts:
+			return script
+
+		scriptFunction = getattr(script, "__func__", script)
+		if scriptFunction not in self._layerWrappers:
+
+			@functools.wraps(script)
+			def wrappedScript(layerGesture: inputCore.InputGesture):
+				try:
+					script(layerGesture)
+				finally:
+					self._finishLayer()
+
+			self._layerWrappers[scriptFunction] = wrappedScript
+
+		return self._layerWrappers[scriptFunction]
+
+	def _finishLayer(self) -> None:
+		"""Leave the resource monitor command layer."""
+		self._isLayerActive = False
+		self.clearGestureBindings()
+		self.bindGestures(self.__gestures)
+
+	def _handleLayerError(self, gesture: inputCore.InputGesture) -> None:
+		"""Report an unbound command-layer gesture and pass it through."""
+		tones.beep(440, 100)
+		self._finishLayer()
+		try:
+			gesture.send()
+		except NotImplementedError:
+			pass
+
+	def _getResourceSummary(self) -> str:
+		"""Build the overall resource usage summary."""
+		return _("{ramPercent}% RAM used, CPU at {cpuPercent}%.").format(
+			ramPercent=tryTrunk(psutil.virtual_memory()[2]), cpuPercent=tryTrunk(psutil.cpu_percent())
+		)
+
+	@scriptHandler.script(
+		# Translators: Input help mode message for entering the Resource Monitor command layer.
+		description=_("Enter the Resource Monitor command layer."),
+		speakOnDemand=True,
+	)
+	def script_layerEntry(self, gesture: inputCore.InputGesture):
+		"""Enter the Resource Monitor command layer."""
+		if self._isLayerActive:
+			self._handleLayerError(gesture)
+			return
+		self.bindGestures(self.__layerGestures)
+		self._isLayerActive = True
+		tones.beep(100, 10)
+		# Translators: Prompt shown after entering the Resource Monitor command layer.
+		ui.message(f"{self._getResourceSummary()} {_('Press a letter for more information.')}")
+
+	@scriptHandler.script(allowInSleepMode=True)
+	def script_layerExit(self, gesture: inputCore.InputGesture):
+		self._finishLayer()
+
 	@scriptHandler.script(
 		# Translators: Input help mode message about overall system resource info command in Resource Monitor
-		description=_("Presents used ram and average processor load."),
-		gesture="KB:NVDA+shift+e",
+		description=_(
+			"Presents used ram and average processor load. "
+			"If pressed twice, copies the information to the clipboard."
+		),
 		speakOnDemand=True,
 	)
 	def script_announceResourceSummary(self, gesture: inputCore.InputGesture):
 		# Faster to build info on the fly rather than keep appending to a string.
 		# Translators: presents the overall summary of resource usage, such as CPU load and RAM usage.
-		info = [
-			_("{ramPercent}% RAM used, CPU at {cpuPercent}%.").format(
-				ramPercent=tryTrunk(psutil.virtual_memory()[2]), cpuPercent=tryTrunk(psutil.cpu_percent())
-			)
-		]
-		ui.message(" ".join(info))
+		info = self._getResourceSummary()
+		if scriptHandler.getLastScriptRepeatCount() == 0:
+			ui.message(info)
+		else:
+			api.copyToClip(info, notify=True)
 
 	@scriptHandler.script(
 		# Translators: Input help mode message about processor info command in Resource Monitor.
@@ -384,7 +480,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Presents the average processor load and the load of each core. "
 			"If pressed twice, copies the information to the clipboard."
 		),
-		gesture="KB:NVDA+shift+1",
 		speakOnDemand=True,
 	)
 	def script_announceProcessorInfo(self, gesture: inputCore.InputGesture):
@@ -417,7 +512,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Presents the used and total space for both physical and virtual ram. "
 			"If pressed twice, copies the information to the clipboard."
 		),
-		gestures=["KB:NVDA+shift+2", "KB:NVDA+shift+5"],
 		speakOnDemand=True,
 	)
 	def script_announceRamInfo(self, gesture: inputCore.InputGesture):
@@ -448,7 +542,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Presents the used and total space of the fixed (built-in), removable, and mapped network drives on this computer. "
 			"If pressed twice, copies the information to the clipboard."
 		),
-		gesture="KB:NVDA+shift+3",
 		speakOnDemand=True,
 	)
 	def script_announceDriveInfo(self, gesture: inputCore.InputGesture):
@@ -538,7 +631,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Announces the system's wireless network name (SSID), connection strength, and security  protocol. "
 			"If pressed twice, copies the information to the clipboard."
 		),
-		gesture="kb:NVDA+shift+4",
 		speakOnDemand=True,
 	)
 	def script_wlanStatusReport(self, gesture: inputCore.InputGesture):
@@ -554,7 +646,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Announces the version of Windows you are using. "
 			"If pressed twice, copies the information to the clipboard."
 		),
-		gesture="KB:NVDA+shift+6",
 		speakOnDemand=True,
 	)
 	def script_announceWinVer(self, gesture: inputCore.InputGesture):
@@ -598,7 +689,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"Announces the system's uptime. "
 			"If pressed twice, copies the information to the clipboard."
 		),
-		gesture="kb:NVDA+shift+7",
 		speakOnDemand=True,
 	)
 	def script_announceUptime(self, gesture: inputCore.InputGesture):

--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -308,6 +308,7 @@ def getWinVer() -> str:
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	# Translators: The gestures category for this add-on in input gestures dialog (2013.3 or later).
 	scriptCategory = _("Resource Monitor")
+	_layerEntryGesture = "kb:NVDA+shift+e"
 	__layerGestures = {
 		"kb:space": "announceResourceSummary",
 		"kb:c": "announceProcessorInfo",
@@ -320,10 +321,15 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"kb:shift+g": "announceGpuMemoryInfo",
 		"kb:escape": "layerExit",
 	}
+	_layerGestureIdentifiers = frozenset(
+		inputCore.normalizeGestureIdentifier(identifier)
+		for identifier in (*__layerGestures, _layerEntryGesture)
+	)
 
 	def __init__(self):
 		super().__init__()
 		self._isLayerActive = False
+		inputCore.decide_executeGesture.register(self._decideExecuteGesture)
 		self._gpuProviders: list[BaseGpuProvider] = getGpuProviders()
 		NVDASettingsDialog.categoryClasses.append(ResourceMonitorSettingsPanel)
 		if not wlanapiAvailable:
@@ -351,6 +357,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			pass
 
 	def terminate(self):
+		inputCore.decide_executeGesture.unregister(self._decideExecuteGesture)
 		super().terminate()
 		self._gpuProviders.clear()
 		if ResourceMonitorSettingsPanel in NVDASettingsDialog.categoryClasses:
@@ -376,11 +383,15 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		except OSError:
 			pass
 
-	def getScript(self, gesture: inputCore.InputGesture):
-		"""Resolve gestures through the resource monitor command layer."""
-		if not self._isLayerActive:
-			return super().getScript(gesture)
-		return super().getScript(gesture) or self._handleUnboundLayerGesture
+	def _decideExecuteGesture(self, gesture: inputCore.InputGesture) -> bool:
+		"""Exit the command layer before an unrelated gesture is resolved."""
+		if (
+			self._isLayerActive
+			and not gesture.isModifier
+			and self._layerGestureIdentifiers.isdisjoint(gesture.normalizedIdentifiers)
+		):
+			self._finishLayer()
+		return True
 
 	def _finishLayer(self) -> None:
 		"""Leave the resource monitor command layer."""
@@ -388,23 +399,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		for gestureIdentifier in self.__layerGestures:
 			self.removeGestureBinding(gestureIdentifier)
 
-	def _handleUnboundLayerGesture(self, gesture: inputCore.InputGesture) -> None:
-		"""Leave the command layer and pass through an unbound gesture."""
-		self._finishLayer()
-		try:
-			gesture.send()
-		except NotImplementedError:
-			pass
-
 	@scriptHandler.script(
 		# Translators: Input help mode message for entering the Resource Monitor command layer.
 		description=_("Enter the Resource Monitor command layer."),
-		gesture="kb:NVDA+shift+e",
+		gesture=_layerEntryGesture,
 	)
 	def script_layerEntry(self, gesture: inputCore.InputGesture):
 		"""Enter the Resource Monitor command layer."""
 		if self._isLayerActive:
-			self._handleUnboundLayerGesture(gesture)
 			return
 		self.bindGestures(self.__layerGestures)
 		self._isLayerActive = True

--- a/readme.md
+++ b/readme.md
@@ -8,23 +8,17 @@ This add-on gives information about CPU load, memory usage and other resource us
 
 All commands support speech on demand mode.
 
-* NVDA+Shift+E: presents used RAM (physical memory) and average processor load.
-* NVDA+Shift+1: presents the average processor load and if multicore CPU's are present the load of each core.
-* NVDA+Shift+2/5: presents the used and total space for both physical and virtual RAM (NVDA+Shift+5 is an alternative to NVDA+Shift+2 when the latter keyboard combination cannot be performed).
-* NVDA+Shift+3: presents the used and total space of the fixed (built-in), removable, and network drives.
-* NVDA+Shift+4: presents information on the wireless connection, network (SSID) name and strength, or no SSID if there is none available.
-* NVDA+Shift+6: presents  Windows version, CPU architecture (AMD64 (x64), ARM64), and exact build number (build.revision).
-* NVDA+Shift+7: presents the system's uptime.
-* Unassigned: presents information about the graphics processing unit (GPU; unavailable in secure mode).
-* Unassigned: presents graphics processing unit (GPU memory usage information; unavailable in secure mode).
+* NVDA+Shift+E: enters the Resource Monitor command layer.
+* In the command layer, press Space for overall resource usage, C for CPU load, M for memory usage, D for disk usage, W for wireless status, V for Windows version, U for uptime, G for GPU usage, or R for GPU memory usage. Press Escape to exit the layer.
+* The individual resource commands are unassigned by default and can be configured in the input gestures dialog.
 
-You can change these shortcut keys via input gestures dialog.
+You can change the command layer entry gesture and assign additional gestures to individual resource commands via the input gestures dialog.
 
 ## Usage notes
 
 This add-on does not replace task manager and other system information programs for Windows. Also note the following:
 
-* Apart from overall resource usage command (NVDA+Shift+E), pressing other commands twice will copy resource usage information to the clipboard.
+* Pressing resource commands twice will copy resource usage information to the clipboard.
 * Resource information cannot be copied to the clipboard if running the add-on in secure screens.
 * CPU usage is given for logical processors, not physical cores. This is noticeable for processors with Hyper-Threading where number of CPU's is twice the number of CPU cores. On some newer computers, not all CPU cores will have hyper-threading enabled.
 * If there is heavy disk activity such as copying large files or while locating network drives, there might be delays when obtaining disk usage information.

--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,11 @@ This add-on gives information about CPU load, memory usage and other resource us
 All commands support speech on demand mode.
 
 * NVDA+Shift+E: enters the Resource Monitor command layer.
-* In the command layer, press Space for overall resource usage, C for CPU load, M for memory usage, D for disk usage, W for wireless status, V for Windows version, U for uptime, G for GPU usage, or R for GPU memory usage. Press Escape to exit the layer.
-* The individual resource commands are unassigned by default and can be configured in the input gestures dialog.
+* In the command layer, press Space for overall resource usage, C for CPU load, M for memory usage, D for disk usage, W for wireless status, O for Windows version, U for uptime, G for GPU usage, or Shift+G for GPU memory usage.
+* Resource commands keep the layer active so they can be repeated. Press Escape to exit the layer; an unmapped key exits and is passed through.
+* For limited backward compatibility, the previous NVDA+Shift+1 through NVDA+Shift+7 resource shortcuts remain available.
 
-You can change the command layer entry gesture and assign additional gestures to individual resource commands via the input gestures dialog.
+You can change these gestures via the input gestures dialog.
 
 ## Usage notes
 


### PR DESCRIPTION
Closes #68

## Problem

Resource Monitor previously assigned several global shortcuts for individual resource commands. This increased the likelihood of conflicts with NVDA and other add-ons.

## Changes

This change introduces a command layer while preserving the existing resource reporting functionality:

- `NVDA+Shift+E` is now the only default global gesture and enters the Resource Monitor command layer.
- Following Joseph Lee's suggestion, resource commands use mnemonic first-letter gestures instead of number-row gestures.
- `Space` reports the overall resource summary.
- Individual resource commands no longer have default global gestures, but remain available for optional user-configured gestures.
- Resource commands remain active while the layer is open, allowing repeated checks.
- Pressing a resource command twice within NVDA's configured multi-press timeout copies the information to the clipboard.
- Unmapped gestures play an error tone, exit the layer, and are passed through to the active application.
- Entering the layer plays a short tone and reports the overall resource summary, followed by a prompt for the available commands.
- The README has been updated to document the new command-layer behavior.

## Command layer gestures

| Gesture | Action |
| --- | --- |
| `Space` | Overall resource summary |
| `C` | CPU information |
| `M` | Memory information |
| `D` | Disk information |
| `W` | Wireless status |
| `V` | Windows version |
| `U` | System uptime |
| `G` | GPU information |
| `R` | GPU memory information |
| `Escape` | Exit the command layer |

## Testing

Manual testing was performed for command-layer entry, all resource commands, repeated checks, double-press clipboard copying, unmapped key pass-through, and layer exit.