### PR TITLE
Fix WLAN client handle cleanup

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -380,7 +380,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				None,
 			)
 			wlanapi.WlanCloseHandle(
-				byref(self._client_handle),
+				self._client_handle,
 				None,
 			)
 			self._client_handle = None


### PR DESCRIPTION
Pass the WLAN client handle directly to `WlanCloseHandle` during plugin termination. Passing `byref(handle)` supplied a pointer instead of the required `HANDLE`, which could leave the WLAN session open.

Reference:
- https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlanclosehandle