### PR TITLE
Handle WLAN API buffer cleanup

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -562,37 +562,51 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return _("No wireless devices")
 
 		wlan_ifaces = POINTER(wlanapi.WLAN_INTERFACE_INFO_LIST)()
-		wlanapi.WlanEnumInterfaces(self._client_handle, None, byref(wlan_ifaces))
+		try:
+			try:
+				wlanapi.WlanEnumInterfaces(self._client_handle, None, byref(wlan_ifaces))
+			except OSError:
+				return _("Unable to get wireless information")
 
-		if wlan_ifaces.contents.NumberOfItems == 0:
-			wlanapi.WlanFreeMemory(wlan_ifaces)
-			return _("No wireless devices")
+			if wlan_ifaces.contents.NumberOfItems == 0:
+				return _("No wireless devices")
 
-		for i in customResize(wlan_ifaces.contents.InterfaceInfo, wlan_ifaces.contents.NumberOfItems):
-			if i.isState != wlanapi.wlan_interface_state_connected:
-				info = _("No wireless connections")
-				continue
+			for i in customResize(wlan_ifaces.contents.InterfaceInfo, wlan_ifaces.contents.NumberOfItems):
+				if i.isState != wlanapi.wlan_interface_state_connected:
+					info = _("No wireless connections")
+					continue
 
-			wlan_available_network_list = POINTER(wlanapi.WLAN_AVAILABLE_NETWORK_LIST)()
-			wlanapi.WlanGetAvailableNetworkList(
-				self._client_handle, byref(i.InterfaceGuid), 0, None, byref(wlan_available_network_list)
-			)
-			for n in customResize(
-				wlan_available_network_list.contents.Network,
-				wlan_available_network_list.contents.NumberOfItems,
-			):
-				if n.Flags & wlanapi.WLAN_AVAILABLE_NETWORK_CONNECTED:
-					info = _(
-						"Connected to {}, signal strength: {}%, security type: {}"
-					).format(
-						n.dot11Ssid.SSID.decode(),
-						n.wlanSignalQuality,
-						SECURITY_TYPE.get(n.dot11DefaultAuthAlgorithm),
+				wlan_available_network_list = POINTER(wlanapi.WLAN_AVAILABLE_NETWORK_LIST)()
+				try:
+					wlanapi.WlanGetAvailableNetworkList(
+						self._client_handle,
+						byref(i.InterfaceGuid),
+						0,
+						None,
+						byref(wlan_available_network_list),
 					)
-					break
-			wlanapi.WlanFreeMemory(wlan_available_network_list)
-		wlanapi.WlanFreeMemory(wlan_ifaces)
-		return info
+				except OSError:
+					return _("Unable to get wireless information")
+
+				try:
+					for n in customResize(
+						wlan_available_network_list.contents.Network,
+						wlan_available_network_list.contents.NumberOfItems,
+					):
+						if n.Flags & wlanapi.WLAN_AVAILABLE_NETWORK_CONNECTED:
+							info = _("Connected to {}, signal strength: {}%, security type: {}").format(
+								n.dot11Ssid.SSID.decode(),
+								n.wlanSignalQuality,
+								SECURITY_TYPE.get(n.dot11DefaultAuthAlgorithm),
+							)
+							break
+				finally:
+					if wlan_available_network_list:
+						wlanapi.WlanFreeMemory(wlan_available_network_list)
+			return info
+		finally:
+			if wlan_ifaces:
+				wlanapi.WlanFreeMemory(wlan_ifaces)
 
 	@scriptHandler.script(
 		# Translators: Input help mode message about obtaining the ssid of the wireless network,

--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -560,13 +560,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def _getWlanInfo(self) -> str:
 		if not self._client_handle:
 			return _("No wireless devices")
+		errorMessage = _("Unable to get wireless information")
 
 		wlan_ifaces = POINTER(wlanapi.WLAN_INTERFACE_INFO_LIST)()
 		try:
 			try:
 				wlanapi.WlanEnumInterfaces(self._client_handle, None, byref(wlan_ifaces))
 			except OSError:
-				return _("Unable to get wireless information")
+				return errorMessage
 
 			if wlan_ifaces.contents.NumberOfItems == 0:
 				return _("No wireless devices")
@@ -586,7 +587,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 						byref(wlan_available_network_list),
 					)
 				except OSError:
-					return _("Unable to get wireless information")
+					return errorMessage
 
 				try:
 					for n in customResize(


### PR DESCRIPTION
`WlanEnumInterfaces` and `WlanGetAvailableNetworkList` allocate result buffers on success. Microsoft requires callers to release them with `WlanFreeMemory` after use.

Previously, the add-on freed these buffers only on the normal path, so an exception during an API call or result processing could skip cleanup.

This change uses `finally` blocks to release every allocated buffer and handles API failures by returning a user-facing error message.

References:
- https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlanenuminterfaces
- https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlangetavailablenetworklist
- https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlanfreememory